### PR TITLE
Better sanity check in case of multiple EOCD files.

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -2271,8 +2271,8 @@ archive_read_support_format_zip_capabilities_seekable(struct archive_read * a)
  * that later bidders can do nothing if they know they'll never
  * outbid.  But we can certainly do better...
  */
-static int
-read_eocd(struct zip *zip, const char *p, int64_t current_offset)
+static int read_eocd(struct zip *zip,
+	const char *p, int64_t current_offset, int64_t file_length)
 {
 	/* Sanity-check the EOCD we've found. */
 
@@ -2288,6 +2288,9 @@ read_eocd(struct zip *zip, const char *p, int64_t current_offset)
 	/* Central directory can't extend beyond start of EOCD record. */
 	if (archive_le32dec(p + 16) + archive_le32dec(p + 12)
 	    > current_offset)
+		return 0;
+	/* The rest of the file must be part of the header's comment. */
+	if (archive_le16dec(p + 20) + current_offset + 22 != file_length)
 		return 0;
 
 	/* Save the central directory location for later use. */
@@ -2381,7 +2384,7 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 		case 006:
 			if (memcmp(p + i, "PK\005\006", 4) == 0) {
 				int ret = read_eocd(zip, p + i,
-						current_offset + i);
+						current_offset + i, file_size);
 				if (ret > 0)
 					return (ret);
 			}


### PR DESCRIPTION
It may happen that a file has multiple EOCD headers in the last 16k of the
archive. In such case, the first one would be chosen.

This can be simply avoided by adding a sanity check, that the entire rest of
the file is in the EOCD comment, which is a valid assumption according to the
ZIP file format specification.

TEST=Tested manually with such ZIP archive.
BUG=None
