### PR TITLE
Fix broken decryption for ZIP files.

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1285,7 +1285,8 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 	if (zip->tctx_valid || zip->cctx_valid) {
 		if (zip->decrypted_bytes_remaining < (size_t)bytes_avail) {
 			size_t buff_remaining = zip->decrypted_buffer_size
-			    - (zip->decrypted_ptr - zip->decrypted_buffer);
+			    - (zip->decrypted_ptr - zip->decrypted_buffer)
+			    - zip->decrypted_bytes_remaining;
 
 			if (buff_remaining > (size_t)bytes_avail)
 				buff_remaining = (size_t)bytes_avail;


### PR DESCRIPTION
Sometimes, decompressing was failing due to miscalculation of buffer
offsets, and hence causing a silent buffer overflow.

When a previous chunk decompression left some bytes in the decryption
buffer, it was not taken into account in determining space left in the
decompression buffer.

So, it could happen, that the decryption buffer is completely full,
but some bytes are not used yet. In such case, even though the buffer
is full, the code tried to decrypt more bytes behind it's boundary.

This CL resolves this issue by properly calculating the amount of
space left in the decompression buffer.